### PR TITLE
Fix conflicting declaration of math.h functions

### DIFF
--- a/lendefs.h
+++ b/lendefs.h
@@ -91,6 +91,7 @@ inline intl min(intl in1,intl in2)
 {
 	if (in1<in2) return in1; else return in2;
 }
+#ifndef _GLIBCXX_CMATH
 inline float fmax(float in1,float in2)
 {
 	if (in1>in2) return in1; else return in2;
@@ -99,3 +100,4 @@ inline float fmin(float in1,float in2)
 {
 	if (in1<in2) return in1; else return in2;
 }
+#endif


### PR DESCRIPTION
Only declare fmin and fmax if math.h is not included in the compilation.